### PR TITLE
rust: remove guard for rust-bindgen bug

### DIFF
--- a/rust/helpers.c
+++ b/rust/helpers.c
@@ -80,7 +80,3 @@ void rust_helper_kunmap(struct page *page)
 	return kunmap(page);
 }
 EXPORT_SYMBOL(rust_helper_kunmap);
-
-// See https://github.com/rust-lang/rust-bindgen/issues/1671
-static_assert(__builtin_types_compatible_p(size_t, uintptr_t),
-	"size_t must match uintptr_t, what architecture is this??");


### PR DESCRIPTION
The bug which this guard protects against
(https://github.com/rust-lang/rust-bindgen/issues/1671)
was fixed upstream as of rust-bindgen v0.53:
https://github.com/rust-lang/rust-bindgen/pull/1688
d650823839f7 ("Remove size_t to usize conversion")

The current recommended rust-bindgen version for building
the Linux kernel is v0.56, so the guard can be safely
dropped.

Signed-off-by: Sven Van Asbroeck <thesven73@gmail.com>