### PR TITLE
CI: fail workflow if debug kernel log contains BUG: or WARNING:

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -304,6 +304,10 @@ jobs:
           grep '] rust_semaphore_c: Rust semaphore sample (in C, for comparison) (init)$' qemu-stdout.log
           grep '] rust_semaphore_c: Rust semaphore sample (in C, for comparison) (exit)$' qemu-stdout.log
 
+      - run: |
+          grep -v '] BUG:' qemu-stdout.log
+          grep -v '] WARNING:' qemu-stdout.log
+
       # Report
       - run: |
           ls -l \


### PR DESCRIPTION
Make sure that BUG: or WARNING: messages in the kernel log
do not get overlooked.

Signed-off-by: Sven Van Asbroeck <thesven73@gmail.com>