### PR TITLE
rust/error: add helper function to convert a pointer to a `Result`

### DIFF
--- a/rust/helpers.c
+++ b/rust/helpers.c
@@ -105,6 +105,18 @@ size_t rust_helper_copy_to_iter(const void *addr, size_t bytes, struct iov_iter 
 }
 EXPORT_SYMBOL_GPL(rust_helper_copy_to_iter);
 
+bool rust_helper_is_err(__force const void *ptr)
+{
+	return IS_ERR(ptr);
+}
+EXPORT_SYMBOL_GPL(rust_helper_is_err);
+
+long rust_helper_ptr_err(__force const void *ptr)
+{
+	return PTR_ERR(ptr);
+}
+EXPORT_SYMBOL_GPL(rust_helper_ptr_err);
+
 #if !defined(CONFIG_ARM)
 // See https://github.com/rust-lang/rust-bindgen/issues/1671
 static_assert(__builtin_types_compatible_p(size_t, uintptr_t),

--- a/rust/kernel/error.rs
+++ b/rust/kernel/error.rs
@@ -104,3 +104,55 @@ impl From<AllocError> for Error {
         Error::ENOMEM
     }
 }
+
+// # Invariant: `-bindings::MAX_ERRNO` fits in an `i16`.
+crate::static_assert!(bindings::MAX_ERRNO as i64 <= -(i16::MIN as i64));
+
+/// Transform a kernel "error pointer" to a normal pointer.
+///
+/// Some kernel C API functions return an "error pointer" which optionally
+/// embeds an `errno`. Callers are supposed to check the returned pointer
+/// for errors. This function performs the check and converts the "error pointer"
+/// to a normal pointer in an idiomatic fashion.
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// fn devm_platform_ioremap_resource(
+///     pdev: &mut PlatformDevice,
+///     index: u32,
+/// ) -> Result<*mut c_types::c_void> {
+///     // SAFETY: FFI call.
+///     unsafe {
+///         ptr_err_check(bindings::devm_platform_ioremap_resource(
+///             pdev.to_ptr(),
+///             index,
+///         ))
+///     }
+/// }
+/// ```
+// TODO: remove `dead_code` marker once an in-kernel client is available.
+#[allow(dead_code)]
+pub(crate) unsafe fn ptr_err_check<T>(ptr: *mut T) -> Result<*mut T> {
+    extern "C" {
+        #[allow(improper_ctypes)]
+        fn rust_helper_is_err(ptr: *const c_types::c_void) -> bool;
+
+        #[allow(improper_ctypes)]
+        fn rust_helper_ptr_err(ptr: *const c_types::c_void) -> c_types::c_long;
+    }
+
+    // SAFETY: any pointer can be safely cast to a `*const c_types::c_void`.
+    let const_ptr = ptr as *const c_types::c_void;
+    if rust_helper_is_err(const_ptr) {
+        return Err(Error::from_kernel_errno(
+            // NO-OVERFLOW: if `rust_helper_is_err()` returns `true`,
+            // then `rust_helper_ptr_err()` is guaranteed to return a
+            // negative value greater-or-equal to `-bindings::MAX_ERRNO`,
+            // which always fits in an `i16`, as per the invariant above.
+            // And an `i16` always fits in an `i32`. So the cast is safe.
+            rust_helper_ptr_err(const_ptr) as i32,
+        ));
+    }
+    Ok(ptr)
+}


### PR DESCRIPTION
Some kernel C API functions return a pointer which embeds an optional
`errno`. Callers are supposed to check the returned pointer with
`IS_ERR()` and if this returns `true`, retrieve the `errno` using
`PTR_ERR`.

Create a Rust helper function to implement the Rust equivalent:
transform a `*mut T` to `Result<*mut T>`.

Co-Created-By: Boqun Feng <boqun.feng@gmail.com>
Co-Created-By: Miguel Ojeda <ojeda@users.noreply.github.com>
Signed-off-by: Sven Van Asbroeck <thesven73@gmail.com>