### PR TITLE
rust/error: add helper function to convert a C error pointer to a `Re…

### DIFF
--- a/rust/helpers.c
+++ b/rust/helpers.c
@@ -105,6 +105,18 @@ size_t rust_helper_copy_to_iter(const void *addr, size_t bytes, struct iov_iter 
 }
 EXPORT_SYMBOL_GPL(rust_helper_copy_to_iter);
 
+bool rust_helper_is_err(__force const void *ptr)
+{
+	return IS_ERR(ptr);
+}
+EXPORT_SYMBOL_GPL(rust_helper_is_err);
+
+long rust_helper_ptr_err(__force const void *ptr)
+{
+	return PTR_ERR(ptr);
+}
+EXPORT_SYMBOL_GPL(rust_helper_ptr_err);
+
 #if !defined(CONFIG_ARM)
 // See https://github.com/rust-lang/rust-bindgen/issues/1671
 static_assert(__builtin_types_compatible_p(size_t, uintptr_t),


### PR DESCRIPTION
…sult`

Some kernel C API functions return a pointer which embeds an optional
`errno`. Callers are supposed to check the returned pointer with
`IS_ERR()` and if this returns `true`, retrieve the `errno` using
`PTR_ERR()`.

Create a Rust helper function to implement the Rust equivalent:
transform a `*mut T` to `Result<*mut T>`.

Co-Created-By: Boqun Feng <boqun.feng@gmail.com>
Co-Created-By: Miguel Ojeda <ojeda@users.noreply.github.com>
Signed-off-by: Sven Van Asbroeck <thesven73@gmail.com>