### PR TITLE
rust-samples: miscdev: eliminate unsafe code block

### DIFF
--- a/rust/kernel/lib.rs
+++ b/rust/kernel/lib.rs
@@ -44,6 +44,7 @@ pub mod file;
 pub mod file_operations;
 pub mod miscdev;
 pub mod pages;
+pub mod traits;
 
 pub mod linked_list;
 mod raw_list;

--- a/rust/kernel/traits.rs
+++ b/rust/kernel/traits.rs
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: GPL-2.0
+
+//! Traits useful to Drivers, and their implementations for common types.
+
+use core::{ops::Deref, pin::Pin};
+
+use alloc::{alloc::AllocError, sync::Arc};
+
+/// Trait which implements a fallible version of `pin()` for any pointer type.
+///
+/// Common pointer types which implement `pin()` include `Box`, `Arc` and `Rc`.
+pub trait TryPin<P: Deref> {
+    /// Constructs a new Pin<pointer<T>>. If T does not implement Unpin, then data
+    /// will be pinned in memory and unable to be moved. An error will be returned
+    /// if allocation fails.
+    fn try_pin(data: P::Target) -> core::result::Result<Pin<P>, AllocError>;
+}
+
+impl<T> TryPin<Arc<T>> for Arc<T> {
+    fn try_pin(data: T) -> core::result::Result<Pin<Arc<T>>, AllocError> {
+        // SAFETY: the data T is exposed only through a `Pin<Arc<T>>`, which
+        // does not allow data to move out of the `Arc`. Therefore it can
+        // never be moved.
+        Ok(unsafe { Pin::new_unchecked(Arc::try_new(data)?) })
+    }
+}

--- a/rust/kernel/traits.rs
+++ b/rust/kernel/traits.rs
@@ -1,16 +1,16 @@
 // SPDX-License-Identifier: GPL-2.0
 
-//! Traits useful to Drivers, and their implementations for common types.
+//! Traits useful to drivers, and their implementations for common types.
 
 use core::{ops::Deref, pin::Pin};
 
 use alloc::{alloc::AllocError, sync::Arc};
 
-/// Trait which implements a fallible version of `pin()` for any pointer type.
+/// Trait which provides a fallible version of `pin()` for pointer types.
 ///
-/// Common pointer types which implement `pin()` include `Box`, `Arc` and `Rc`.
+/// Common pointer types which implement a `pin()` method include [`Box`], [`Arc`] and [`Rc`].
 pub trait TryPin<P: Deref> {
-    /// Constructs a new Pin<pointer<T>>. If T does not implement Unpin, then data
+    /// Constructs a new `Pin<pointer<T>>`. If `T` does not implement [`Unpin`], then data
     /// will be pinned in memory and unable to be moved. An error will be returned
     /// if allocation fails.
     fn try_pin(data: P::Target) -> core::result::Result<Pin<P>, AllocError>;
@@ -18,7 +18,7 @@ pub trait TryPin<P: Deref> {
 
 impl<T> TryPin<Arc<T>> for Arc<T> {
     fn try_pin(data: T) -> core::result::Result<Pin<Arc<T>>, AllocError> {
-        // SAFETY: the data T is exposed only through a `Pin<Arc<T>>`, which
+        // SAFETY: the data `T` is exposed only through a `Pin<Arc<T>>`, which
         // does not allow data to move out of the `Arc`. Therefore it can
         // never be moved.
         Ok(unsafe { Pin::new_unchecked(Arc::try_new(data)?) })

--- a/samples/rust/rust_miscdev.rs
+++ b/samples/rust/rust_miscdev.rs
@@ -15,6 +15,7 @@ use kernel::{
     io_buffer::{IoBufferReader, IoBufferWriter},
     miscdev,
     sync::{CondVar, Mutex},
+    traits::TryPin,
     Error,
 };
 
@@ -39,19 +40,16 @@ struct SharedState {
 
 impl SharedState {
     fn try_new() -> Result<Pin<Arc<Self>>> {
-        // SAFETY: `state` is pinning `Arc`, which implements `Unpin`.
-        let state = unsafe {
-            Pin::new_unchecked(Arc::try_new(Self {
-                // SAFETY: `condvar_init!` is called below.
-                state_changed: CondVar::new(),
-                // SAFETY: `mutex_init!` is called below.
-                inner: Mutex::new(SharedStateInner { token_count: 0 }),
-            })?)
-        };
-        // SAFETY: `state_changed` is pinned behind `Arc`.
+        let state = Arc::try_pin(Self {
+            // SAFETY: `condvar_init!` is called below.
+            state_changed: unsafe { CondVar::new() },
+            // SAFETY: `mutex_init!` is called below.
+            inner: unsafe { Mutex::new(SharedStateInner { token_count: 0 }) },
+        })?;
+        // SAFETY: `state_changed` is pinned behind `Pin<Arc>`.
         let state_changed = unsafe { Pin::new_unchecked(&state.state_changed) };
         kernel::condvar_init!(state_changed, "SharedState::state_changed");
-        // SAFETY: `inner` is pinned behind `Arc`.
+        // SAFETY: `inner` is pinned behind `Pin<Arc>`.
         let inner = unsafe { Pin::new_unchecked(&state.inner) };
         kernel::mutex_init!(inner, "SharedState::inner");
         Ok(state)


### PR DESCRIPTION
AFAIK we can create a `Pin<Arc<T>>` using only safe code,
by calling `Arc::pin(T)`. This also eliminates a fallible
memory allocation.

While we're here, also update the `// SAFETY` proofs for
the mutex and condvar inits, which had gone stale.

Signed-off-by: Sven Van Asbroeck <thesven73@gmail.com>