### PR TITLE
rust/kernel: Error: remove config `#ifdef` in .rs file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -516,7 +516,7 @@ KBUILD_RUSTCFLAGS := --emit=dep-info,obj,metadata --edition=2018 \
 		     -Cpanic=abort -Cembed-bitcode=n -Clto=n -Crpath=n \
 		     -Cforce-unwind-tables=n -Ccodegen-units=1 \
 		     -Zbinary_dep_depinfo=y -Zsymbol-mangling-version=v0 \
-		     -W unsafe_op_in_unsafe_fn
+		     -D unsafe_op_in_unsafe_fn
 KBUILD_AFLAGS_KERNEL :=
 KBUILD_CFLAGS_KERNEL :=
 KBUILD_RUSTCFLAGS_KERNEL :=

--- a/drivers/android/node.rs
+++ b/drivers/android/node.rs
@@ -83,12 +83,14 @@ impl NodeDeath {
             cookie,
             work_links: Links::new(),
             death_links: Links::new(),
-            inner: SpinLock::new(NodeDeathInner {
-                dead: false,
-                cleared: false,
-                notification_done: false,
-                aborted: false,
-            }),
+            inner: unsafe {
+                SpinLock::new(NodeDeathInner {
+                    dead: false,
+                    cleared: false,
+                    notification_done: false,
+                    aborted: false,
+                })
+            },
         }
     }
 

--- a/rust/helpers.c
+++ b/rust/helpers.c
@@ -8,6 +8,7 @@
 #include <linux/highmem.h>
 #include <linux/uio.h>
 #include <linux/errname.h>
+#include <linux/mutex.h>
 
 void rust_helper_BUG(void)
 {
@@ -122,6 +123,12 @@ const char *rust_helper_errname(int err)
 {
 	return errname(err);
 }
+
+void rust_helper_mutex_lock(struct mutex *lock)
+{
+	mutex_lock(lock);
+}
+EXPORT_SYMBOL_GPL(rust_helper_mutex_lock);
 
 /* We use bindgen's --size_t-is-usize option to bind the C size_t type
  * as the Rust usize type, so we can use it in contexts where Rust

--- a/rust/helpers.c
+++ b/rust/helpers.c
@@ -7,6 +7,7 @@
 #include <linux/gfp.h>
 #include <linux/highmem.h>
 #include <linux/uio.h>
+#include <linux/errname.h>
 
 void rust_helper_BUG(void)
 {
@@ -116,6 +117,11 @@ long rust_helper_ptr_err(__force const void *ptr)
 	return PTR_ERR(ptr);
 }
 EXPORT_SYMBOL_GPL(rust_helper_ptr_err);
+
+const char *rust_helper_errname(int err)
+{
+	return errname(err);
+}
 
 /* We use bindgen's --size_t-is-usize option to bind the C size_t type
  * as the Rust usize type, so we can use it in contexts where Rust

--- a/rust/kernel/allocator.rs
+++ b/rust/kernel/allocator.rs
@@ -14,11 +14,13 @@ unsafe impl GlobalAlloc for KernelAllocator {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
         // `krealloc()` is used instead of `kmalloc()` because the latter is
         // an inline function and cannot be bound to as a result.
-        bindings::krealloc(ptr::null(), layout.size(), bindings::GFP_KERNEL) as *mut u8
+        unsafe { bindings::krealloc(ptr::null(), layout.size(), bindings::GFP_KERNEL) as *mut u8 }
     }
 
     unsafe fn dealloc(&self, ptr: *mut u8, _layout: Layout) {
-        bindings::kfree(ptr as *const c_types::c_void);
+        unsafe {
+            bindings::kfree(ptr as *const c_types::c_void);
+        }
     }
 }
 

--- a/rust/kernel/bindings.rs
+++ b/rust/kernel/bindings.rs
@@ -9,7 +9,8 @@
     non_camel_case_types,
     non_upper_case_globals,
     non_snake_case,
-    improper_ctypes
+    improper_ctypes,
+    unsafe_op_in_unsafe_fn
 )]
 mod bindings_raw {
     use crate::c_types;

--- a/rust/kernel/error.rs
+++ b/rust/kernel/error.rs
@@ -98,11 +98,11 @@ impl Error {
 
 impl fmt::Debug for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        extern "C" {
+            fn rust_helper_errname(err: c_types::c_int) -> *const c_types::c_char;
+        }
         // SAFETY: FFI call.
-        #[cfg(CONFIG_SYMBOLIC_ERRNAME)]
-        let name = unsafe { crate::bindings::errname(-self.0) };
-        #[cfg(not(CONFIG_SYMBOLIC_ERRNAME))]
-        let name: *const c_types::c_char = core::ptr::null();
+        let name = unsafe { rust_helper_errname(-self.0) };
 
         if name.is_null() {
             // Print out number if no name can be found.

--- a/rust/kernel/file_operations.rs
+++ b/rust/kernel/file_operations.rs
@@ -57,10 +57,10 @@ impl PollTable {
 
         // SAFETY: `PollTable::ptr` is guaranteed to be valid by the type invariants and the null
         // check above.
-        let table = &*self.ptr;
+        let table = unsafe { &*self.ptr };
         if let Some(proc) = table._qproc {
             // SAFETY: All pointers are known to be valid.
-            proc(file.ptr as _, cv.wait_list.get(), self.ptr)
+            unsafe { proc(file.ptr as _, cv.wait_list.get(), self.ptr) }
         }
     }
 }
@@ -84,9 +84,9 @@ unsafe extern "C" fn open_callback<A: FileOpenAdapter, T: FileOpener<A::Arg>>(
     file: *mut bindings::file,
 ) -> c_types::c_int {
     from_kernel_result! {
-        let arg = A::convert(inode, file);
-        let ptr = T::open(&*arg)?.into_pointer();
-        (*file).private_data = ptr as *mut c_types::c_void;
+        let arg = unsafe { A::convert(inode, file) };
+        let ptr = T::open(unsafe { &*arg })?.into_pointer();
+        unsafe { (*file).private_data = ptr as *mut c_types::c_void };
         Ok(0)
     }
 }
@@ -98,12 +98,12 @@ unsafe extern "C" fn read_callback<T: FileOperations>(
     offset: *mut bindings::loff_t,
 ) -> c_types::c_ssize_t {
     from_kernel_result! {
-        let mut data = UserSlicePtr::new(buf as *mut c_types::c_void, len).writer();
-        let f = &*((*file).private_data as *const T);
+        let mut data = unsafe { UserSlicePtr::new(buf as *mut c_types::c_void, len).writer() };
+        let f = unsafe { &*((*file).private_data as *const T) };
         // No `FMODE_UNSIGNED_OFFSET` support, so `offset` must be in [0, 2^63).
         // See discussion in https://github.com/fishinabarrel/linux-kernel-module-rust/pull/113
-        let read = f.read(&FileRef::from_ptr(file), &mut data, (*offset).try_into()?)?;
-        (*offset) += bindings::loff_t::try_from(read).unwrap();
+        let read = f.read(unsafe { &FileRef::from_ptr(file) }, &mut data, unsafe { *offset }.try_into()?)?;
+        unsafe { (*offset) += bindings::loff_t::try_from(read).unwrap() };
         Ok(read as _)
     }
 }
@@ -113,12 +113,12 @@ unsafe extern "C" fn read_iter_callback<T: FileOperations>(
     raw_iter: *mut bindings::iov_iter,
 ) -> isize {
     from_kernel_result! {
-        let mut iter = IovIter::from_ptr(raw_iter);
-        let file = (*iocb).ki_filp;
-        let offset = (*iocb).ki_pos;
-        let f = &*((*file).private_data as *const T);
-        let read = f.read(&FileRef::from_ptr(file), &mut iter, offset.try_into()?)?;
-        (*iocb).ki_pos += bindings::loff_t::try_from(read).unwrap();
+        let mut iter = unsafe { IovIter::from_ptr(raw_iter) };
+        let file = unsafe { (*iocb).ki_filp };
+        let offset = unsafe { (*iocb).ki_pos };
+        let f = unsafe { &*((*file).private_data as *const T) };
+        let read = f.read(unsafe { &FileRef::from_ptr(file) }, &mut iter, offset.try_into()?)?;
+        unsafe { (*iocb).ki_pos += bindings::loff_t::try_from(read).unwrap() };
         Ok(read as _)
     }
 }
@@ -130,12 +130,12 @@ unsafe extern "C" fn write_callback<T: FileOperations>(
     offset: *mut bindings::loff_t,
 ) -> c_types::c_ssize_t {
     from_kernel_result! {
-        let mut data = UserSlicePtr::new(buf as *mut c_types::c_void, len).reader();
-        let f = &*((*file).private_data as *const T);
+        let mut data = unsafe { UserSlicePtr::new(buf as *mut c_types::c_void, len).reader() };
+        let f = unsafe { &*((*file).private_data as *const T) };
         // No `FMODE_UNSIGNED_OFFSET` support, so `offset` must be in [0, 2^63).
         // See discussion in https://github.com/fishinabarrel/linux-kernel-module-rust/pull/113
-        let written = f.write(&FileRef::from_ptr(file), &mut data, (*offset).try_into()?)?;
-        (*offset) += bindings::loff_t::try_from(written).unwrap();
+        let written = f.write(unsafe { &FileRef::from_ptr(file) }, &mut data, unsafe { *offset }.try_into()?)?;
+        unsafe { (*offset) += bindings::loff_t::try_from(written).unwrap() };
         Ok(written as _)
     }
 }
@@ -145,12 +145,12 @@ unsafe extern "C" fn write_iter_callback<T: FileOperations>(
     raw_iter: *mut bindings::iov_iter,
 ) -> isize {
     from_kernel_result! {
-        let mut iter = IovIter::from_ptr(raw_iter);
-        let file = (*iocb).ki_filp;
-        let offset = (*iocb).ki_pos;
-        let f = &*((*file).private_data as *const T);
-        let written = f.write(&FileRef::from_ptr(file), &mut iter, offset.try_into()?)?;
-        (*iocb).ki_pos += bindings::loff_t::try_from(written).unwrap();
+        let mut iter = unsafe { IovIter::from_ptr(raw_iter) };
+        let file = unsafe { (*iocb).ki_filp };
+        let offset = unsafe { (*iocb).ki_pos };
+        let f = unsafe { &*((*file).private_data as *const T) };
+        let written = f.write(unsafe { &FileRef::from_ptr(file) }, &mut iter, offset.try_into()?)?;
+        unsafe { (*iocb).ki_pos += bindings::loff_t::try_from(written).unwrap() };
         Ok(written as _)
     }
 }
@@ -159,8 +159,10 @@ unsafe extern "C" fn release_callback<T: FileOperations>(
     _inode: *mut bindings::inode,
     file: *mut bindings::file,
 ) -> c_types::c_int {
-    let ptr = mem::replace(&mut (*file).private_data, ptr::null_mut());
-    T::release(T::Wrapper::from_pointer(ptr as _), &FileRef::from_ptr(file));
+    let ptr = mem::replace(unsafe { &mut (*file).private_data }, ptr::null_mut());
+    T::release(unsafe { T::Wrapper::from_pointer(ptr as _) }, unsafe {
+        &FileRef::from_ptr(file)
+    });
     0
 }
 
@@ -176,8 +178,8 @@ unsafe extern "C" fn llseek_callback<T: FileOperations>(
             bindings::SEEK_END => SeekFrom::End(offset),
             _ => return Err(Error::EINVAL),
         };
-        let f = &*((*file).private_data as *const T);
-        let off = f.seek(&FileRef::from_ptr(file), off)?;
+        let f = unsafe { &*((*file).private_data as *const T) };
+        let off = f.seek(unsafe { &FileRef::from_ptr(file) }, off)?;
         Ok(off as bindings::loff_t)
     }
 }
@@ -188,10 +190,10 @@ unsafe extern "C" fn unlocked_ioctl_callback<T: FileOperations>(
     arg: c_types::c_ulong,
 ) -> c_types::c_long {
     from_kernel_result! {
-        let f = &*((*file).private_data as *const T);
+        let f = unsafe { &*((*file).private_data as *const T) };
         // SAFETY: This function is called by the kernel, so it must set `fs` appropriately.
         let mut cmd = IoctlCommand::new(cmd as _, arg as _);
-        let ret = f.ioctl(&FileRef::from_ptr(file), &mut cmd)?;
+        let ret = f.ioctl(unsafe { &FileRef::from_ptr(file) }, &mut cmd)?;
         Ok(ret as _)
     }
 }
@@ -202,10 +204,10 @@ unsafe extern "C" fn compat_ioctl_callback<T: FileOperations>(
     arg: c_types::c_ulong,
 ) -> c_types::c_long {
     from_kernel_result! {
-        let f = &*((*file).private_data as *const T);
+        let f = unsafe { &*((*file).private_data as *const T) };
         // SAFETY: This function is called by the kernel, so it must set `fs` appropriately.
         let mut cmd = IoctlCommand::new(cmd as _, arg as _);
-        let ret = f.compat_ioctl(&FileRef::from_ptr(file), &mut cmd)?;
+        let ret = f.compat_ioctl(unsafe { &FileRef::from_ptr(file) }, &mut cmd)?;
         Ok(ret as _)
     }
 }
@@ -215,8 +217,8 @@ unsafe extern "C" fn mmap_callback<T: FileOperations>(
     vma: *mut bindings::vm_area_struct,
 ) -> c_types::c_int {
     from_kernel_result! {
-        let f = &*((*file).private_data as *const T);
-        f.mmap(&FileRef::from_ptr(file), &mut *vma)?;
+        let f = unsafe { &*((*file).private_data as *const T) };
+        f.mmap(unsafe { &FileRef::from_ptr(file) }, unsafe { &mut *vma })?;
         Ok(0)
     }
 }
@@ -231,8 +233,8 @@ unsafe extern "C" fn fsync_callback<T: FileOperations>(
         let start = start.try_into()?;
         let end = end.try_into()?;
         let datasync = datasync != 0;
-        let f = &*((*file).private_data as *const T);
-        let res = f.fsync(&FileRef::from_ptr(file), start, end, datasync)?;
+        let f = unsafe { &*((*file).private_data as *const T) };
+        let res = f.fsync(unsafe { &FileRef::from_ptr(file) }, start, end, datasync)?;
         Ok(res.try_into().unwrap())
     }
 }
@@ -241,8 +243,10 @@ unsafe extern "C" fn poll_callback<T: FileOperations>(
     file: *mut bindings::file,
     wait: *mut bindings::poll_table_struct,
 ) -> bindings::__poll_t {
-    let f = &*((*file).private_data as *const T);
-    match f.poll(&FileRef::from_ptr(file), &PollTable::from_ptr(wait)) {
+    let f = unsafe { &*((*file).private_data as *const T) };
+    match f.poll(unsafe { &FileRef::from_ptr(file) }, unsafe {
+        &PollTable::from_ptr(wait)
+    }) {
         Ok(v) => v,
         Err(_) => bindings::POLLERR,
     }

--- a/rust/kernel/iov_iter.rs
+++ b/rust/kernel/iov_iter.rs
@@ -70,7 +70,7 @@ impl IoBufferWriter for IovIter {
     }
 
     unsafe fn write_raw(&mut self, data: *const u8, len: usize) -> Result {
-        let res = rust_helper_copy_to_iter(data as _, len, self.ptr);
+        let res = unsafe { rust_helper_copy_to_iter(data as _, len, self.ptr) };
         if res != len {
             Err(Error::EFAULT)
         } else {
@@ -85,7 +85,7 @@ impl IoBufferReader for IovIter {
     }
 
     unsafe fn read_raw(&mut self, out: *mut u8, len: usize) -> Result {
-        let res = rust_helper_copy_from_iter(out as _, len, self.ptr);
+        let res = unsafe { rust_helper_copy_from_iter(out as _, len, self.ptr) };
         if res != len {
             Err(Error::EFAULT)
         } else {

--- a/rust/kernel/lib.rs
+++ b/rust/kernel/lib.rs
@@ -210,7 +210,7 @@ macro_rules! offset_of {
 macro_rules! container_of {
     ($ptr:expr, $type:ty, $($f:tt)*) => {{
         let offset = $crate::offset_of!($type, $($f)*);
-        ($ptr as *const _ as *const u8).offset(-offset) as *const $type
+        unsafe { ($ptr as *const _ as *const u8).offset(-offset) as *const $type }
     }}
 }
 

--- a/rust/kernel/linked_list.rs
+++ b/rust/kernel/linked_list.rs
@@ -33,7 +33,7 @@ impl<T: ?Sized> Wrapper<T> for Box<T> {
     }
 
     unsafe fn from_pointer(ptr: NonNull<T>) -> Self {
-        Box::from_raw(ptr.as_ptr())
+        unsafe { Box::from_raw(ptr.as_ptr()) }
     }
 
     fn as_ref(&self) -> &T {
@@ -47,7 +47,7 @@ impl<T: ?Sized> Wrapper<T> for Arc<T> {
     }
 
     unsafe fn from_pointer(ptr: NonNull<T>) -> Self {
-        Arc::from_raw(ptr.as_ptr())
+        unsafe { Arc::from_raw(ptr.as_ptr()) }
     }
 
     fn as_ref(&self) -> &T {
@@ -61,7 +61,7 @@ impl<T: ?Sized> Wrapper<T> for &T {
     }
 
     unsafe fn from_pointer(ptr: NonNull<T>) -> Self {
-        &*ptr.as_ptr()
+        unsafe { &*ptr.as_ptr() }
     }
 
     fn as_ref(&self) -> &T {
@@ -149,10 +149,10 @@ impl<G: GetLinksWrapped> List<G> {
     /// Callers must ensure that `existing` points to a valid entry that is on the list.
     pub unsafe fn insert_after(&mut self, existing: NonNull<G::EntryType>, data: G::Wrapped) {
         let ptr = data.into_pointer();
-        let entry = &*existing.as_ptr();
-        if !self.list.insert_after(entry, ptr.as_ref()) {
+        let entry = unsafe { &*existing.as_ptr() };
+        if unsafe { !self.list.insert_after(entry, ptr.as_ref()) } {
             // If insertion failed, rebuild object so that it can be freed.
-            G::Wrapped::from_pointer(ptr);
+            unsafe { G::Wrapped::from_pointer(ptr) };
         }
     }
 
@@ -164,8 +164,8 @@ impl<G: GetLinksWrapped> List<G> {
     /// list leads to memory unsafety.
     pub unsafe fn remove(&mut self, data: &G::Wrapped) -> Option<G::Wrapped> {
         let entry_ref = Wrapper::as_ref(data);
-        if self.list.remove(entry_ref) {
-            Some(G::Wrapped::from_pointer(NonNull::from(entry_ref)))
+        if unsafe { self.list.remove(entry_ref) } {
+            Some(unsafe { G::Wrapped::from_pointer(NonNull::from(entry_ref)) })
         } else {
             None
         }

--- a/rust/kernel/miscdev.rs
+++ b/rust/kernel/miscdev.rs
@@ -85,8 +85,11 @@ impl<T: Sync> FileOpenAdapter for Registration<T> {
     type Arg = T;
 
     unsafe fn convert(_inode: *mut bindings::inode, file: *mut bindings::file) -> *const Self::Arg {
+        // TODO: `SAFETY` comment required here even if `unsafe` is not present,
+        // because `container_of!` hides it. Ideally we would not allow
+        // `unsafe` code as parameters to macros.
         let reg = crate::container_of!((*file).private_data, Self, mdev);
-        &(*reg).context
+        unsafe { &(*reg).context }
     }
 }
 

--- a/rust/kernel/module_param.rs
+++ b/rust/kernel/module_param.rs
@@ -71,12 +71,12 @@ pub trait ModuleParam: core::fmt::Display + core::marker::Sized {
         let arg = if val.is_null() {
             None
         } else {
-            Some(CStr::from_char_ptr(val).as_bytes())
+            Some(unsafe { CStr::from_char_ptr(val).as_bytes() })
         };
         match Self::try_from_param_arg(arg) {
             Some(new_value) => {
-                let old_value = (*param).__bindgen_anon_1.arg as *mut Self;
-                let _ = core::ptr::replace(old_value, new_value);
+                let old_value = unsafe { (*param).__bindgen_anon_1.arg as *mut Self };
+                let _ = unsafe { core::ptr::replace(old_value, new_value) };
                 0
             }
             None => crate::error::Error::EINVAL.to_kernel_errno(),
@@ -95,9 +95,9 @@ pub trait ModuleParam: core::fmt::Display + core::marker::Sized {
         buf: *mut crate::c_types::c_char,
         param: *const crate::bindings::kernel_param,
     ) -> crate::c_types::c_int {
-        let slice = core::slice::from_raw_parts_mut(buf as *mut u8, crate::PAGE_SIZE);
+        let slice = unsafe { core::slice::from_raw_parts_mut(buf as *mut u8, crate::PAGE_SIZE) };
         let mut buf = crate::buffer::Buffer::new(slice);
-        match write!(buf, "{}\0", *((*param).__bindgen_anon_1.arg as *mut Self)) {
+        match unsafe { write!(buf, "{}\0", *((*param).__bindgen_anon_1.arg as *mut Self)) } {
             Err(_) => crate::error::Error::EINVAL.to_kernel_errno(),
             Ok(()) => buf.bytes_written() as crate::c_types::c_int,
         }
@@ -111,7 +111,7 @@ pub trait ModuleParam: core::fmt::Display + core::marker::Sized {
     ///
     /// The `arg` field of `param` must be an instance of `Self`.
     unsafe extern "C" fn free(arg: *mut crate::c_types::c_void) {
-        core::ptr::drop_in_place(arg as *mut Self);
+        unsafe { core::ptr::drop_in_place(arg as *mut Self) };
     }
 }
 

--- a/rust/kernel/of.rs
+++ b/rust/kernel/of.rs
@@ -69,6 +69,6 @@ impl PointerWrapper for OfMatchTable {
     }
 
     unsafe fn from_pointer(p: *const c_types::c_void) -> Self {
-        Self(InnerTable::from_pointer(p))
+        Self(unsafe { InnerTable::from_pointer(p) })
     }
 }

--- a/rust/kernel/of.rs
+++ b/rust/kernel/of.rs
@@ -69,6 +69,7 @@ impl PointerWrapper for OfMatchTable {
     }
 
     unsafe fn from_pointer(p: *const c_types::c_void) -> Self {
+        // SAFETY: The passed pointer comes from a previous call to [`InnerTable::into_pointer()`].
         Self(unsafe { InnerTable::from_pointer(p) })
     }
 }

--- a/rust/kernel/pages.rs
+++ b/rust/kernel/pages.rs
@@ -107,7 +107,7 @@ impl<const ORDER: u32> Pages<ORDER> {
         }
 
         let mapping = self.kmap(0).ok_or(Error::EINVAL)?;
-        ptr::copy((mapping.ptr as *mut u8).add(offset), dest, len);
+        unsafe { ptr::copy((mapping.ptr as *mut u8).add(offset), dest, len) };
         Ok(())
     }
 
@@ -127,7 +127,7 @@ impl<const ORDER: u32> Pages<ORDER> {
         }
 
         let mapping = self.kmap(0).ok_or(Error::EINVAL)?;
-        ptr::copy(src, (mapping.ptr as *mut u8).add(offset), len);
+        unsafe { ptr::copy(src, (mapping.ptr as *mut u8).add(offset), len) };
         Ok(())
     }
 

--- a/rust/kernel/print.rs
+++ b/rust/kernel/print.rs
@@ -53,7 +53,7 @@ unsafe fn rust_fmt_argument(buf: *mut c_char, end: *mut c_char, ptr: *const c_vo
         buf: buf as _,
         end: end as _,
     };
-    let _ = w.write_fmt(*(ptr as *const fmt::Arguments<'_>));
+    let _ = w.write_fmt(unsafe { *(ptr as *const fmt::Arguments<'_>) });
     w.buf as _
 }
 
@@ -132,11 +132,13 @@ pub unsafe fn call_printk(
     args: fmt::Arguments<'_>,
 ) {
     // `printk` does not seem to fail in any path.
-    bindings::printk(
-        format_string.as_ptr() as _,
-        module_name.as_ptr(),
-        &args as *const _ as *const c_void,
-    );
+    unsafe {
+        bindings::printk(
+            format_string.as_ptr() as _,
+            module_name.as_ptr(),
+            &args as *const _ as *const c_void,
+        );
+    }
 }
 
 /// Prints a message via the kernel's [`printk`] for the `CONT` level.

--- a/rust/kernel/raw_list.rs
+++ b/rust/kernel/raw_list.rs
@@ -132,7 +132,7 @@ impl<G: GetLinks> RawList<G> {
         }
 
         // SAFETY: The links are now owned by the list, so it is safe to get a mutable reference.
-        let new_entry = &mut *links.entry.get();
+        let new_entry = unsafe { &mut *links.entry.get() };
         self.insert_after_priv(existing, new_entry, Some(NonNull::from(new)));
         true
     }

--- a/rust/kernel/str.rs
+++ b/rust/kernel/str.rs
@@ -89,8 +89,10 @@ impl CStr {
     /// must not be mutated.
     #[inline]
     pub unsafe fn from_char_ptr<'a>(ptr: *const c_types::c_char) -> &'a Self {
-        let len = bindings::strlen(ptr) + 1;
-        Self::from_bytes_with_nul_unchecked(core::slice::from_raw_parts(ptr as _, len as _))
+        let len = unsafe { bindings::strlen(ptr) } + 1;
+        unsafe {
+            Self::from_bytes_with_nul_unchecked(core::slice::from_raw_parts(ptr as _, len as _))
+        }
     }
 
     /// Creates a [`CStr`] from a `[u8]`.
@@ -144,7 +146,7 @@ impl CStr {
         // requires `ptr_metadata`).
         // While none of them are current stable, it is very likely that one of
         // them will eventually be.
-        &*(bytes as *const [u8] as *const Self)
+        unsafe { &*(bytes as *const [u8] as *const Self) }
     }
 
     /// Returns a C pointer to the string.

--- a/rust/kernel/str.rs
+++ b/rust/kernel/str.rs
@@ -193,11 +193,10 @@ impl Index<ops::RangeFrom<usize>> for CStr {
     type Output = CStr;
 
     #[inline]
-    // Clippy false positive
-    #[allow(clippy::unnecessary_operation)]
     fn index(&self, index: ops::RangeFrom<usize>) -> &Self::Output {
         // Delegate bounds checking to slice.
-        &self.as_bytes()[index.start..];
+        // Assign to _ to mute clippy's unnecessary operation warning.
+        let _ = &self.as_bytes()[index.start..];
         // SAFETY: We just checked the bounds.
         unsafe { Self::from_bytes_with_nul_unchecked(&self.0[index.start..]) }
     }

--- a/rust/kernel/str.rs
+++ b/rust/kernel/str.rs
@@ -89,10 +89,14 @@ impl CStr {
     /// must not be mutated.
     #[inline]
     pub unsafe fn from_char_ptr<'a>(ptr: *const c_types::c_char) -> &'a Self {
+        // SAFETY: The safety precondition guarantees `ptr` is a valid pointer
+        // to a `NUL`-terminated C string.
         let len = unsafe { bindings::strlen(ptr) } + 1;
-        unsafe {
-            Self::from_bytes_with_nul_unchecked(core::slice::from_raw_parts(ptr as _, len as _))
-        }
+        // SAFETY: Lifetime guaranteed by the safety precondition.
+        let bytes = unsafe { core::slice::from_raw_parts(ptr as _, len as _) };
+        // SAFETY: As `len` is returned by `strlen`, `bytes` does not contain interior `NUL`.
+        // As we have added 1 to `len`, the last byte is known to be `NUL`.
+        unsafe { Self::from_bytes_with_nul_unchecked(bytes) }
     }
 
     /// Creates a [`CStr`] from a `[u8]`.
@@ -146,6 +150,7 @@ impl CStr {
         // requires `ptr_metadata`).
         // While none of them are current stable, it is very likely that one of
         // them will eventually be.
+        // SAFETY: Properties of `bytes` guaranteed by the safety precondition.
         unsafe { &*(bytes as *const [u8] as *const Self) }
     }
 

--- a/rust/kernel/sync/condvar.rs
+++ b/rust/kernel/sync/condvar.rs
@@ -132,6 +132,6 @@ impl CondVar {
 
 impl NeedsLockClass for CondVar {
     unsafe fn init(self: Pin<&Self>, name: &'static CStr, key: *mut bindings::lock_class_key) {
-        bindings::__init_waitqueue_head(self.wait_list.get(), name.as_char_ptr(), key);
+        unsafe { bindings::__init_waitqueue_head(self.wait_list.get(), name.as_char_ptr(), key) };
     }
 }

--- a/rust/kernel/sync/mutex.rs
+++ b/rust/kernel/sync/mutex.rs
@@ -73,7 +73,7 @@ impl<T: ?Sized> Mutex<T> {
 
 impl<T: ?Sized> NeedsLockClass for Mutex<T> {
     unsafe fn init(self: Pin<&Self>, name: &'static CStr, key: *mut bindings::lock_class_key) {
-        bindings::__mutex_init(self.mutex.get(), name.as_char_ptr(), key);
+        unsafe { bindings::__mutex_init(self.mutex.get(), name.as_char_ptr(), key) };
     }
 }
 
@@ -93,7 +93,7 @@ impl<T: ?Sized> Lock for Mutex<T> {
     }
 
     unsafe fn unlock(&self) {
-        bindings::mutex_unlock(self.mutex.get());
+        unsafe { bindings::mutex_unlock(self.mutex.get()) };
     }
 
     fn locked_data(&self) -> &UnsafeCell<T> {

--- a/rust/kernel/sync/mutex.rs
+++ b/rust/kernel/sync/mutex.rs
@@ -77,19 +77,16 @@ impl<T: ?Sized> NeedsLockClass for Mutex<T> {
     }
 }
 
+extern "C" {
+    fn rust_helper_mutex_lock(mutex: *mut bindings::mutex);
+}
+
 impl<T: ?Sized> Lock for Mutex<T> {
     type Inner = T;
 
-    #[cfg(not(CONFIG_DEBUG_LOCK_ALLOC))]
     fn lock_noguard(&self) {
         // SAFETY: `mutex` points to valid memory.
-        unsafe { bindings::mutex_lock(self.mutex.get()) };
-    }
-
-    #[cfg(CONFIG_DEBUG_LOCK_ALLOC)]
-    fn lock_noguard(&self) {
-        // SAFETY: `mutex` points to valid memory.
-        unsafe { bindings::mutex_lock_nested(self.mutex.get(), 0) };
+        unsafe { rust_helper_mutex_lock(self.mutex.get()); }
     }
 
     unsafe fn unlock(&self) {

--- a/rust/kernel/sync/spinlock.rs
+++ b/rust/kernel/sync/spinlock.rs
@@ -87,7 +87,7 @@ impl<T: ?Sized> SpinLock<T> {
 
 impl<T: ?Sized> NeedsLockClass for SpinLock<T> {
     unsafe fn init(self: Pin<&Self>, name: &'static CStr, key: *mut bindings::lock_class_key) {
-        rust_helper_spin_lock_init(self.spin_lock.get(), name.as_char_ptr(), key);
+        unsafe { rust_helper_spin_lock_init(self.spin_lock.get(), name.as_char_ptr(), key) };
     }
 }
 
@@ -100,7 +100,7 @@ impl<T: ?Sized> Lock for SpinLock<T> {
     }
 
     unsafe fn unlock(&self) {
-        rust_helper_spin_unlock(self.spin_lock.get());
+        unsafe { rust_helper_spin_unlock(self.spin_lock.get()) };
     }
 
     fn locked_data(&self) -> &UnsafeCell<T> {

--- a/rust/kernel/sysctl.rs
+++ b/rust/kernel/sysctl.rs
@@ -103,13 +103,13 @@ unsafe extern "C" fn proc_handler<T: SysctlStorage>(
 ) -> c_types::c_int {
     // If we are reading from some offset other than the beginning of the file,
     // return an empty read to signal EOF.
-    if *ppos != 0 && write == 0 {
-        *len = 0;
+    if unsafe { *ppos } != 0 && write == 0 {
+        unsafe { *len = 0 };
         return 0;
     }
 
-    let data = UserSlicePtr::new(buffer, *len);
-    let storage = &*((*ctl).data as *const T);
+    let data = unsafe { UserSlicePtr::new(buffer, *len) };
+    let storage = unsafe { &*((*ctl).data as *const T) };
     let (bytes_processed, result) = if write != 0 {
         let data = match data.read_all() {
             Ok(r) => r,
@@ -120,8 +120,8 @@ unsafe extern "C" fn proc_handler<T: SysctlStorage>(
         let mut writer = data.writer();
         storage.read_value(&mut writer)
     };
-    *len = bytes_processed;
-    *ppos += *len as bindings::loff_t;
+    unsafe { *len = bytes_processed };
+    unsafe { *ppos += *len as bindings::loff_t };
     match result {
         Ok(()) => 0,
         Err(e) => e.to_kernel_errno(),

--- a/rust/kernel/types.rs
+++ b/rust/kernel/types.rs
@@ -54,7 +54,7 @@ impl<T> PointerWrapper for Box<T> {
     }
 
     unsafe fn from_pointer(ptr: *const c_types::c_void) -> Self {
-        Box::from_raw(ptr as _)
+        unsafe { Box::from_raw(ptr as _) }
     }
 }
 
@@ -64,7 +64,7 @@ impl<T: RefCounted> PointerWrapper for Ref<T> {
     }
 
     unsafe fn from_pointer(ptr: *const c_types::c_void) -> Self {
-        Ref::from_raw(ptr as _)
+        unsafe { Ref::from_raw(ptr as _) }
     }
 }
 
@@ -74,7 +74,7 @@ impl<T> PointerWrapper for Arc<T> {
     }
 
     unsafe fn from_pointer(ptr: *const c_types::c_void) -> Self {
-        Arc::from_raw(ptr as _)
+        unsafe { Arc::from_raw(ptr as _) }
     }
 }
 
@@ -87,8 +87,8 @@ impl<T: PointerWrapper + Deref> PointerWrapper for Pin<T> {
     }
 
     unsafe fn from_pointer(p: *const c_types::c_void) -> Self {
-        // SAFETY: The object was originally pinned.
-        Pin::new_unchecked(T::from_pointer(p))
+        // TODO: Review: SAFETY: The object was originally pinned.
+        unsafe { Pin::new_unchecked(T::from_pointer(p)) }
     }
 }
 

--- a/rust/kernel/types.rs
+++ b/rust/kernel/types.rs
@@ -54,6 +54,7 @@ impl<T> PointerWrapper for Box<T> {
     }
 
     unsafe fn from_pointer(ptr: *const c_types::c_void) -> Self {
+        // SAFETY: The passed pointer comes from a previous call to [`Self::into_pointer()`].
         unsafe { Box::from_raw(ptr as _) }
     }
 }
@@ -64,6 +65,7 @@ impl<T: RefCounted> PointerWrapper for Ref<T> {
     }
 
     unsafe fn from_pointer(ptr: *const c_types::c_void) -> Self {
+        // SAFETY: The passed pointer comes from a previous call to [`Self::into_pointer()`].
         unsafe { Ref::from_raw(ptr as _) }
     }
 }
@@ -74,6 +76,7 @@ impl<T> PointerWrapper for Arc<T> {
     }
 
     unsafe fn from_pointer(ptr: *const c_types::c_void) -> Self {
+        // SAFETY: The passed pointer comes from a previous call to [`Self::into_pointer()`].
         unsafe { Arc::from_raw(ptr as _) }
     }
 }
@@ -87,7 +90,8 @@ impl<T: PointerWrapper + Deref> PointerWrapper for Pin<T> {
     }
 
     unsafe fn from_pointer(p: *const c_types::c_void) -> Self {
-        // TODO: Review: SAFETY: The object was originally pinned.
+        // SAFETY: The object was originally pinned.
+        // The passed pointer comes from a previous call to `inner::into_pointer()`.
         unsafe { Pin::new_unchecked(T::from_pointer(p)) }
     }
 }

--- a/rust/kernel/user_ptr.rs
+++ b/rust/kernel/user_ptr.rs
@@ -130,7 +130,7 @@ impl IoBufferReader for UserSlicePtrReader {
         if len > self.1 || len > u32::MAX as usize {
             return Err(Error::EFAULT);
         }
-        let res = rust_helper_copy_from_user(out as _, self.0, len as _);
+        let res = unsafe { rust_helper_copy_from_user(out as _, self.0, len as _) };
         if res != 0 {
             return Err(Error::EFAULT);
         }
@@ -177,7 +177,7 @@ impl IoBufferWriter for UserSlicePtrWriter {
         if len > self.1 || len > u32::MAX as usize {
             return Err(Error::EFAULT);
         }
-        let res = rust_helper_copy_to_user(self.0, data as _, len as _);
+        let res = unsafe { rust_helper_copy_to_user(self.0, data as _, len as _) };
         if res != 0 {
             return Err(Error::EFAULT);
         }


### PR DESCRIPTION
The use of `#ifdef CONFIG_` statements in .c/.rs files is deprecated:
it makes the code much more unmaintainable over time. See:
https://lkml.org/lkml/2021/6/3/564

Use a Rust-C helper instead to leverage automatic `CONFIG` selection
in C kernel headers.

Signed-off-by: Sven Van Asbroeck <thesven73@gmail.com>