### PR TITLE
rust/kernel: remove config `#ifdef` in mutex.rs file

### DIFF
--- a/rust/helpers.c
+++ b/rust/helpers.c
@@ -8,6 +8,7 @@
 #include <linux/highmem.h>
 #include <linux/uio.h>
 #include <linux/errname.h>
+#include <linux/mutex.h>
 
 void rust_helper_BUG(void)
 {
@@ -122,6 +123,12 @@ const char *rust_helper_errname(int err)
 {
 	return errname(err);
 }
+
+void rust_helper_mutex_lock(struct mutex *lock)
+{
+	mutex_lock(lock);
+}
+EXPORT_SYMBOL_GPL(rust_helper_mutex_lock);
 
 /* We use bindgen's --size_t-is-usize option to bind the C size_t type
  * as the Rust usize type, so we can use it in contexts where Rust


### PR DESCRIPTION
The use of `#ifdef CONFIG_` statements in .c/.rs files should be
avoided: it makes the code much more unmaintainable over time. See:
https://lore.kernel.org/lkml/YLjWKwhp7akqyR1S@kroah.com/

Use a Rust-C helper instead to leverage automatic `CONFIG` selection
in C kernel headers.

Signed-off-by: Sven Van Asbroeck <thesven73@gmail.com>