### PR TITLE
rust/kernel/of: construct `of_match_table` structure at build time

### DIFF
--- a/drivers/char/hw_random/bcm2835_rng_rust.rs
+++ b/drivers/char/hw_random/bcm2835_rng_rust.rs
@@ -12,7 +12,7 @@ use kernel::{
     file_operations::{FileOpener, FileOperations},
     io_buffer::IoBufferWriter,
     miscdev,
-    of::OfMatchTable,
+    of::ConstOfMatchTable,
     platdev::PlatformDriver,
     prelude::*,
     {c_str, platdev},
@@ -72,11 +72,12 @@ struct RngModule {
 
 impl KernelModule for RngModule {
     fn init() -> Result<Self> {
-        let of_match_tbl = OfMatchTable::new(&c_str!("brcm,bcm2835-rng"))?;
+        const OF_MATCH_TBL: ConstOfMatchTable<1> =
+            ConstOfMatchTable::new_const([&c_str!("brcm,bcm2835-rng")]);
 
         let pdev = platdev::Registration::new_pinned::<RngDriver>(
             c_str!("bcm2835-rng-rust"),
-            Some(of_match_tbl),
+            Some(&OF_MATCH_TBL),
             &THIS_MODULE,
         )?;
 

--- a/rust/kernel/platdev.rs
+++ b/rust/kernel/platdev.rs
@@ -21,7 +21,6 @@ use core::{marker::PhantomPinned, pin::Pin};
 #[derive(Default)]
 pub struct Registration {
     registered: bool,
-    of_table: Option<*const c_types::c_void>,
     pdrv: bindings::platform_driver,
     _pin: PhantomPinned,
 }
@@ -83,7 +82,7 @@ impl Registration {
     fn register<P: PlatformDriver>(
         self: Pin<&mut Self>,
         name: &'static CStr,
-        of_match_table: Option<OfMatchTable>,
+        of_match_table: Option<&'static dyn OfMatchTable>,
         module: &'static crate::ThisModule,
     ) -> Result {
         // SAFETY: We must ensure that we never move out of `this`.
@@ -94,9 +93,7 @@ impl Registration {
         }
         this.pdrv.driver.name = name.as_char_ptr();
         if let Some(tbl) = of_match_table {
-            let ptr = tbl.into_pointer();
-            this.of_table = Some(ptr);
-            this.pdrv.driver.of_match_table = ptr.cast();
+            this.pdrv.driver.of_match_table = tbl.as_ptr();
         }
         this.pdrv.probe = Some(probe_callback::<P>);
         this.pdrv.remove = Some(remove_callback::<P>);
@@ -105,10 +102,9 @@ impl Registration {
         //   - `name` pointer has static lifetime.
         //   - `module.0` lives at least as long as the module.
         //   - `probe()` and `remove()` are static functions.
-        //   - `of_match_table` is either:
-        //      - a raw pointer which lives until after the call to
-        //       `bindings::platform_driver_unregister()`, or
-        //      - null.
+        //   - `of_match_table` is either a raw pointer with static lifetime,
+        //      as guaranteed by the [`of::OfMatchTable::as_ptr()`] invariant,
+        //      or null.
         let ret = unsafe { bindings::__platform_driver_register(&mut this.pdrv, module.0) };
         if ret < 0 {
             return Err(Error::from_kernel_errno(ret));
@@ -122,7 +118,7 @@ impl Registration {
     /// Returns a pinned heap-allocated representation of the registration.
     pub fn new_pinned<P: PlatformDriver>(
         name: &'static CStr,
-        of_match_tbl: Option<OfMatchTable>,
+        of_match_tbl: Option<&'static dyn OfMatchTable>,
         module: &'static crate::ThisModule,
     ) -> Result<Pin<Box<Self>>> {
         let mut r = Pin::from(Box::try_new(Self::default())?);
@@ -138,11 +134,6 @@ impl Drop for Registration {
             // previously, which means `platform_driver_unregister` is always
             // safe to call.
             unsafe { bindings::platform_driver_unregister(&mut self.pdrv) }
-        }
-        if let Some(ptr) = self.of_table {
-            // SAFETY: `ptr` came from an `OfMatchTable`.
-            let tbl = unsafe { OfMatchTable::from_pointer(ptr) };
-            drop(tbl);
         }
     }
 }


### PR DESCRIPTION
Use const generics and const fns to construct our `of_match_table`
structure at build time. A few runtime errors now become build time
errors, which is a good thing.

To avoid the const generics propagating into the platdev's
`Registration` structure definition, use a `dyn trait` to pass
the table into the registration.

Signed-off-by: Sven Van Asbroeck <thesven73@gmail.com>